### PR TITLE
chore: Hide changelogs in renovate PRs

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -4,6 +4,7 @@
     "config:base",
     ":semanticCommitTypeAll(chore)"
   ],
+  "prBodyTemplate": "{{{header}}}{{{table}}}{{{warnings}}}{{{notes}}}{{{configDescription}}}{{{controls}}}{{{footer}}}",
   "enabledManagers": ["npm", "github-actions"],
   "rangeStrategy": "pin",
   "schedule": "every weekend",


### PR DESCRIPTION
So it doesn't trigger linear with magic words