### PR TITLE
fix: Install before build

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -91,12 +91,6 @@ jobs:
           registry-url: "https://npm.fluence.dev"
           cache: "pnpm"
 
-      - run: pnpm -r i
-      - run: pnpm -r build
-
-      - name: Lint code
-        run: pnpm lint-check
-
       - name: Override dependencies
         uses: fluencelabs/github-actions/pnpm-set-dependency@main
         with:
@@ -107,6 +101,11 @@ jobs:
             }
 
       - run: pnpm -r --no-frozen-lockfile i
+      - run: pnpm -r build
+
+      - name: Lint code
+        run: pnpm lint-check
+
       - run: pnpm -r test
 
       - name: Dump container logs

--- a/.prettierignore
+++ b/.prettierignore
@@ -8,6 +8,8 @@ build
 public
 
 **/CHANGELOG.md
+# TODO: remove after pnpm-set-deps will add \n symbol at the end of these files
+**/package.json
 
 packages/core/js-client-isomorphic/src/versions.ts
 __snapshots__


### PR DESCRIPTION
Currently JS client CI doesn't properly substitute dependencies.
After first build it does another install with different version.