### PR TITLE
fix: Enable async loading of all dependency resources

### DIFF
--- a/packages/core/js-client-isomorphic/src/types.ts
+++ b/packages/core/js-client-isomorphic/src/types.ts
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 
+import type { MarineBackgroundInterface } from "@fluencelabs/marine-worker";
 import { ModuleThread } from "@fluencelabs/threads/master";
 
 import versions from "./versions.js";
-import type { MarineBackgroundInterface } from "@fluencelabs/marine-worker";
 
 export type FetchedPackages = keyof typeof versions;
 type VersionedPackage = { name: string; version: string };

--- a/packages/core/js-client-isomorphic/src/types.ts
+++ b/packages/core/js-client-isomorphic/src/types.ts
@@ -14,16 +14,17 @@
  * limitations under the License.
  */
 
-import { Worker } from "@fluencelabs/threads/master";
+import { ModuleThread } from "@fluencelabs/threads/master";
 
 import versions from "./versions.js";
+import type { MarineBackgroundInterface } from "@fluencelabs/marine-worker";
 
 export type FetchedPackages = keyof typeof versions;
 type VersionedPackage = { name: string; version: string };
 export type GetWorkerFn = (
   pkg: FetchedPackages,
   CDNUrl: string,
-) => Promise<Worker>;
+) => Promise<ModuleThread<MarineBackgroundInterface>>;
 
 export const getVersionedPackage = (pkg: FetchedPackages): VersionedPackage => {
   return {

--- a/packages/core/js-client-isomorphic/src/worker-resolvers/browser.ts
+++ b/packages/core/js-client-isomorphic/src/worker-resolvers/browser.ts
@@ -14,10 +14,11 @@
  * limitations under the License.
  */
 
-import { BlobWorker } from "@fluencelabs/threads/master";
+import { BlobWorker, ModuleThread, spawn } from "@fluencelabs/threads/master";
 
 import { fetchResource } from "../fetchers/browser.js";
 import type { FetchedPackages, GetWorkerFn } from "../types.js";
+import type { MarineBackgroundInterface } from "@fluencelabs/marine-worker";
 
 export const getWorker: GetWorkerFn = async (
   pkg: FetchedPackages,
@@ -34,5 +35,9 @@ export const getWorker: GetWorkerFn = async (
   };
 
   const workerCode = await fetchWorkerCode();
-  return BlobWorker.fromText(workerCode);
+
+  const workerThread: ModuleThread<MarineBackgroundInterface> =
+    await spawn<MarineBackgroundInterface>(BlobWorker.fromText(workerCode));
+
+  return workerThread;
 };

--- a/packages/core/js-client-isomorphic/src/worker-resolvers/browser.ts
+++ b/packages/core/js-client-isomorphic/src/worker-resolvers/browser.ts
@@ -14,11 +14,11 @@
  * limitations under the License.
  */
 
+import type { MarineBackgroundInterface } from "@fluencelabs/marine-worker";
 import { BlobWorker, ModuleThread, spawn } from "@fluencelabs/threads/master";
 
 import { fetchResource } from "../fetchers/browser.js";
 import type { FetchedPackages, GetWorkerFn } from "../types.js";
-import type { MarineBackgroundInterface } from "@fluencelabs/marine-worker";
 
 export const getWorker: GetWorkerFn = async (
   pkg: FetchedPackages,

--- a/packages/core/js-client-isomorphic/src/worker-resolvers/node.ts
+++ b/packages/core/js-client-isomorphic/src/worker-resolvers/node.ts
@@ -18,12 +18,13 @@ import { createRequire } from "module";
 import { dirname, relative } from "path";
 import { fileURLToPath } from "url";
 
-import { Worker } from "@fluencelabs/threads/master";
+import { ModuleThread, spawn, Worker } from "@fluencelabs/threads/master";
 
 import type { FetchedPackages, GetWorkerFn } from "../types.js";
 import { getVersionedPackage } from "../types.js";
+import type { MarineBackgroundInterface } from "@fluencelabs/marine-worker";
 
-export const getWorker: GetWorkerFn = (pkg: FetchedPackages) => {
+export const getWorker: GetWorkerFn = async (pkg: FetchedPackages) => {
   const require = createRequire(import.meta.url);
 
   const pathToThisFile = dirname(fileURLToPath(import.meta.url));
@@ -33,5 +34,8 @@ export const getWorker: GetWorkerFn = (pkg: FetchedPackages) => {
 
   const relativePathToWorker = relative(pathToThisFile, pathToWorker);
 
-  return Promise.resolve(new Worker(relativePathToWorker));
+  const workerThread: ModuleThread<MarineBackgroundInterface> =
+    await spawn<MarineBackgroundInterface>(new Worker(relativePathToWorker));
+
+  return workerThread;
 };

--- a/packages/core/js-client-isomorphic/src/worker-resolvers/node.ts
+++ b/packages/core/js-client-isomorphic/src/worker-resolvers/node.ts
@@ -18,11 +18,11 @@ import { createRequire } from "module";
 import { dirname, relative } from "path";
 import { fileURLToPath } from "url";
 
+import type { MarineBackgroundInterface } from "@fluencelabs/marine-worker";
 import { ModuleThread, spawn, Worker } from "@fluencelabs/threads/master";
 
 import type { FetchedPackages, GetWorkerFn } from "../types.js";
 import { getVersionedPackage } from "../types.js";
-import type { MarineBackgroundInterface } from "@fluencelabs/marine-worker";
 
 export const getWorker: GetWorkerFn = async (pkg: FetchedPackages) => {
   const require = createRequire(import.meta.url);

--- a/packages/core/js-client/src/jsPeer/FluencePeer.ts
+++ b/packages/core/js-client/src/jsPeer/FluencePeer.ts
@@ -356,9 +356,8 @@ export abstract class FluencePeer {
       await this.connection.sendParticle(item.result.nextPeerPks, newParticle);
       log_particle.trace("id %s. send successful", newParticle.id);
     } catch (e) {
-      log_particle.error("id %s. send failed %j", newParticle.id, e);
-
       const message = getErrorMessage(e);
+      log_particle.error("id %s. send failed %s", newParticle.id, message);
 
       item.onError(
         new SendError(

--- a/packages/core/js-client/src/marine/loader.ts
+++ b/packages/core/js-client/src/marine/loader.ts
@@ -16,18 +16,19 @@
 
 import { fetchResource } from "@fluencelabs/js-client-isomorphic/fetcher";
 import { getWorker } from "@fluencelabs/js-client-isomorphic/worker-resolver";
-import { Worker } from "@fluencelabs/threads/master";
+import type { ModuleThread } from "@fluencelabs/threads/master";
+import type { MarineBackgroundInterface } from "@fluencelabs/marine-worker";
 
 type StrategyReturnType = [
   marineJsWasm: ArrayBuffer,
   avmWasm: ArrayBuffer,
-  worker: Worker,
+  worker: ModuleThread<MarineBackgroundInterface>,
 ];
 
 export const loadMarineDeps = async (
   CDNUrl: string,
 ): Promise<StrategyReturnType> => {
-  const [marineJsWasm, avmWasm] = await Promise.all([
+  const [marineJsWasm, avmWasm, worker] = await Promise.all([
     fetchResource(
       "@fluencelabs/marine-js",
       "/dist/marine-js.wasm",
@@ -38,10 +39,8 @@ export const loadMarineDeps = async (
     fetchResource("@fluencelabs/avm", "/dist/avm.wasm", CDNUrl).then((res) => {
       return res.arrayBuffer();
     }),
+    getWorker("@fluencelabs/marine-worker", CDNUrl),
   ]);
-
-  // TODO: load worker in parallel with avm and marine, test that it works
-  const worker = await getWorker("@fluencelabs/marine-worker", CDNUrl);
 
   return [marineJsWasm, avmWasm, worker];
 };

--- a/packages/core/js-client/src/marine/loader.ts
+++ b/packages/core/js-client/src/marine/loader.ts
@@ -16,8 +16,8 @@
 
 import { fetchResource } from "@fluencelabs/js-client-isomorphic/fetcher";
 import { getWorker } from "@fluencelabs/js-client-isomorphic/worker-resolver";
-import type { ModuleThread } from "@fluencelabs/threads/master";
 import type { MarineBackgroundInterface } from "@fluencelabs/marine-worker";
+import type { ModuleThread } from "@fluencelabs/threads/master";
 
 type StrategyReturnType = [
   marineJsWasm: ArrayBuffer,


### PR DESCRIPTION
Some notes:
I grouped worker initiation with spawning to prevent unexpected bug. The bug is occurring when there is some time window between worker initiation and call to `spawn` function. More expensive solution is to put some effort in fixing that, but easier one is to group that code together. 