### PR TITLE
fix: Dial interval

### DIFF
--- a/packages/core/js-client/src/connection/RelayConnection.ts
+++ b/packages/core/js-client/src/connection/RelayConnection.ts
@@ -145,7 +145,6 @@ export class RelayConnection implements IConnection {
         ...(this.config.dialTimeoutMs !== undefined
           ? {
               dialTimeout: this.config.dialTimeoutMs,
-              autoDialInterval: 0,
             }
           : {}),
       },


### PR DESCRIPTION
This config was added by mistake. No real benefit in turning the option on.