### PR TITLE
chore: fix FCLI init in CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -76,6 +76,9 @@ jobs:
           artifact: fcli
           version: unstable
 
+      - name: Initialize FCLI
+        run: fluence provider init --env=local --no-input
+
       - name: Run nox network
         run: fluence local up
 


### PR DESCRIPTION
To fix  `Error: Please init provider.yaml using 'fluence provider init' in order to continue` in CI