### PR TITLE
chore: update pnpm/action-setup to v4

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,7 +53,7 @@ jobs:
           token: ${{ secrets.FLUENCEBOT_RELEASE_PLEASE_PAT }}
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v2.2.4
+        uses: pnpm/action-setup@v4
         with:
           version: 8
 
@@ -103,7 +103,7 @@ jobs:
             kv/npmjs/fluencebot token | NODE_AUTH_TOKEN
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v2.2.4
+        uses: pnpm/action-setup@v4
         with:
           version: 8
 

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -43,7 +43,7 @@ jobs:
           repository: fluencelabs/js-client
           ref: ${{ inputs.ref }}
 
-      - uses: pnpm/action-setup@v2.2.4
+      - uses: pnpm/action-setup@v4
         with:
           version: 8
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -83,7 +83,7 @@ jobs:
         run: fluence local up
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v2.4.1
+        uses: pnpm/action-setup@v4
         with:
           version: 8
 


### PR DESCRIPTION
Version 2.2.4 is failing because it is obsolete.